### PR TITLE
Support of Swift Package Manager

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "DeviceKit",
+        "repositoryURL": "https://github.com/devicekit/DeviceKit",
+        "state": {
+          "branch": null,
+          "revision": "4a1c9aa580ae1db763791015e119c4331c95ad02",
+          "version": "2.3.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version:5.1
+
+import PackageDescription
+
+let package = Package(
+    name: "RainbowBar",
+    platforms: [.iOS(.v13)],
+    products: [
+        .library(
+            name: "RainbowBar",
+            targets: ["RainbowBar"]
+        )
+    ],
+    dependencies: [
+        .package(
+            url: "https://github.com/devicekit/DeviceKit",
+            .upToNextMajor(from: "2.0.0")
+        )
+    ],
+    targets: [
+        .target(
+            name: "RainbowBar",
+            dependencies: ["DeviceKit"],
+            path: "RainbowBar"
+        )
+    ]
+)


### PR DESCRIPTION
Adds `Package.swift` and `Package.resolved` files which enable usage with SPM.
**Note**, that the most correct usage with SPM will be possible only when there is new release that includes `Package.swift`. Until then, dependency can be added by branch or commit hash which is not allowed in published packages.